### PR TITLE
javafx sample

### DIFF
--- a/specification/build.gradle
+++ b/specification/build.gradle
@@ -46,7 +46,7 @@ dependencies {
     compile 'org.xerial:sqlite-jdbc:3.7.2'
 }
 
-mainClassName = 'com.teampc.monopoly.TestTool'
+mainClassName = 'com.teampc.monopoly.HelloWorld'
 
 // stolen from: http://stackoverflow.com/questions/24997441/delombok-using-gradle
 task delombok {

--- a/specification/src/main/java/com/teampc/monopoly/HelloWorld.java
+++ b/specification/src/main/java/com/teampc/monopoly/HelloWorld.java
@@ -1,0 +1,28 @@
+package com.teampc.monopoly;
+
+import javafx.application.Application;
+import javafx.event.ActionEvent;
+import javafx.event.EventHandler;
+import javafx.scene.Scene;
+import javafx.scene.control.Button;
+import javafx.scene.layout.StackPane;
+import javafx.stage.Stage;
+
+public class HelloWorld extends Application {
+    public static void main(String... args) {
+        launch(args);
+    }
+
+    @Override
+    public void start(Stage primaryStage) {
+        primaryStage.setTitle("Hello World!");
+        Button btn = new Button();
+        btn.setText("Say 'Hello World'");
+        btn.setOnAction(event -> System.out.println("Hello World!"));
+
+        StackPane root = new StackPane();
+        root.getChildren().add(btn);
+        primaryStage.setScene(new Scene(root, 300, 250));
+        primaryStage.show();
+    }
+}


### PR DESCRIPTION
OpenJDK users may need to install an external javafx package, otherwise it should be built in to java 8.

execute `./gradlew run` to start up the Hello World GUI