### PR TITLE
ViewTests: remove canned data from controllers

### DIFF
--- a/implementation/src/main/java/com/teampc/controller/test/ViewTestController.java
+++ b/implementation/src/main/java/com/teampc/controller/test/ViewTestController.java
@@ -17,10 +17,7 @@ public class ViewTestController implements Initializable {
   @FXML
   private ListView/*<TestRow>*/ viewTestList;
 
-  ObservableList/*<TestRow>*/ data = FXCollections.observableArrayList(
-//        new TestRow(new Test("307 Midterm 1", new Date(11), new Date(11), "307")),
-//        new TestRow(new Test("307 Midterm 2", new Date(11), new Date(11), "307"))
-  );
+  ObservableList/*<TestRow>*/ data = FXCollections.observableArrayList();
 
   @Override
   public void initialize(URL location, ResourceBundle resources) {

--- a/implementation/src/main/java/com/teampc/dao/TestDAO.java
+++ b/implementation/src/main/java/com/teampc/dao/TestDAO.java
@@ -19,12 +19,6 @@ public class TestDAO extends AbstractDAO<Test> {
       return INSTANCE;
    }
 
-   private TestDAO() {
-      // add fake stuff
-      this.insert(new Test("307 Midterm 1", new Date(11), new Date(11), "307"));
-      this.insert(new Test("307 Midterm 2", new Date(11), new Date(11), "307"));
-   }
-
    @Override
    protected Class<Test> getEntityClass() {
       return Test.class;


### PR DESCRIPTION
Took the canned data out of controllers. Pretty simple change. If we want more canned data, we can add it to the "Add Fake Data" button.